### PR TITLE
Add configure script and build documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ SRCS = main.c
 CFLAGS = -Wall -O2
 LDFLAGS = -lcurl -ljansson
 
+-include config.mk
+
 all: $(TARGET)
 
 $(TARGET): $(SRCS)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # aiTerm
-A linux terminal with an AI brain
+
+A Linux terminal with an AI brain.
+
+## Building
+
+This project depends on `libcurl` and `jansson`.
+
+```bash
+./configure
+make
+```
+
+## Running
+
+Execute the compiled binary to start the interactive shell:
+
+```bash
+./ai-shell
+```
+
+Use `exit` to quit the program.

--- a/configure
+++ b/configure
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+if ! command -v pkg-config >/dev/null 2>&1; then
+  echo "Error: pkg-config not found. Please install pkg-config." >&2
+  exit 1
+fi
+
+for lib in libcurl jansson; do
+  if ! pkg-config --exists "$lib"; then
+    echo "Error: Required library $lib not found. Please install it." >&2
+    exit 1
+  fi
+done
+
+CFLAGS=$(pkg-config --cflags libcurl jansson)
+LIBS=$(pkg-config --libs libcurl jansson)
+
+cat > config.mk <<EOF_CONF
+CFLAGS += ${CFLAGS}
+LDFLAGS += ${LIBS}
+EOF_CONF
+
+echo "Configuration complete. Run 'make' to build the project." 

--- a/main.c
+++ b/main.c
@@ -84,6 +84,12 @@ int main(void) {
         curl = curl_easy_init();
         if(curl) {
             struct MemoryStruct chunk = { .memory = malloc(1), .size = 0 };
+            if (!chunk.memory) {
+                fprintf(stderr, "Failed to allocate memory for response.\n");
+                curl_easy_cleanup(curl);
+                continue;
+            }
+
             struct curl_slist *headers = NULL;
             headers = curl_slist_append(headers, "Content-Type: application/json");
 


### PR DESCRIPTION
## Summary
- Add memory allocation check in `main.c` to avoid null pointer use
- Introduce `configure` script for dependency checks and generating `config.mk`
- Document build and run instructions in `README.md`
- Include optional `config.mk` in `Makefile`

## Testing
- `./configure`
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b9cf6452a48326ad8beffcf1207e23